### PR TITLE
Gracefully fail when pandoc is missing.

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -68,10 +68,14 @@ def get_pandoc_formats():
     Dynamic preprocessor for Pandoc formats.
     Return 2 lists. "from_formats" and "to_formats".
     ''' 
-    p = subprocess.Popen(
-            ['pandoc', '-h'],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE)
+    try:
+        p = subprocess.Popen(
+                ['pandoc', '-h'],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE)
+    except OSError:
+        raise OSError("You probably do not have pandoc installed.")
+    
     help_text = p.communicate()[0].decode().splitlines(False)
     txt = ' '.join(help_text[1:help_text.index('Options:')])
 


### PR DESCRIPTION
Instead of:

```
Traceback (most recent call last):
  File "setup.py", line 22, in <module>
    long_description = pypandoc.convert(get_path('README.md'), 'rst')
  File "/usr/local/lib/python2.7/dist-packages/pypandoc.py", line 19, in convert
    return _convert(_read_file, _process_file, source, to, format, extra_args)
  File "/usr/local/lib/python2.7/dist-packages/pypandoc.py", line 37, in _convert
    from_formats, to_formats = get_pandoc_formats()
  File "/usr/local/lib/python2.7/dist-packages/pypandoc.py", line 74, in get_pandoc_formats
    stdout=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 709, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1326, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
