### PR TITLE
Updated pandoc help parsing for available formats.

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -8,7 +8,7 @@ __all__ = ['convert', 'get_pandoc_formats']
 
 import subprocess
 import os
-
+import re
 
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8'):


### PR DESCRIPTION
Textile format didn't work because extra text wasn't stripped.
Also strips '_' from 'pdf_'

If you look at the latest output from `pandoc -h` it has a trailing line that gives more info about exporting to pdf format in the form 

```
[text...]
```

This is now stripped out, as is the '_' from 'pdf_' in the list of formats.
