### PR TITLE
Added "aarch" type check

### DIFF
--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -58,7 +58,8 @@ def _get_pandoc_urls(version="latest"):
     response = urlopen("https://github.com/jgm/pandoc/releases/expanded_assets/"+version)
     content = response.read()
     # regex for the binaries
-    processor_architecture = "arm" if platform.uname()[4].startswith("arm") else "amd"
+    uname = platform.uname()[4]
+    processor_architecture = "arm" if uname.startswith("arm") or uname.startswith("aarch") else "amd"
     regex = re.compile(r"/jgm/pandoc/releases/download/.*(?:"+processor_architecture+"|x86|mac).*\.(?:msi|deb|pkg)")
     # a list of urls to the binaries
     pandoc_urls_list = regex.findall(content.decode("utf-8"))


### PR DESCRIPTION
Fixes issue "Platform architecture of ARM Linux system can be aarch64" https://github.com/JessicaTegner/pypandoc/issues/293.