### PR TITLE
Rename myself and add Juho Vepsäläinen

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Amy Guy](https://github.com/rhiaro) - Exception handling for unicode errors
 * [Florian Eßer](https://github.com/flesser) - Allow Markdown extensions in output format
 * [Philipp Wendler](https://github.com/PhilippWendler) - Allow Markdown extensions in input format
-* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer version of pandoc, return code checking, get_pandoc_version. Helped to fix the Travis build, new `convert_*` API
+* [Jan Katins](https://github.com/jankatins) - Handling output to a file, Travis to work on newer version of pandoc, return code checking, get_pandoc_version. Helped to fix the Travis build, new `convert_*` API. Former maintainer of pypandoc
 * [Aaron Gonzales](https://github.com/xysmas) - Added better filter handling
 * [David Lukes](https://github.com/dlukes) - Enabled input from non-plain-text files and made sure tests clean up template files correctly if they fail
 * [valholl](https://github.com/valholl) - Set up licensing information correctly and include examples to distribution version
@@ -310,6 +310,7 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Andrew Barraford](https://github.com/abarrafo) - Download destination.
 * [Jesse Widner](https://github.com/jwidner) & [Dominic Thorn](https://github.com/domvwt) - Add support for lua filters
 * [Alex Kneisel](https://github.com/hey-thanks/) - Added pathlib.Path support to convert_file.
+* [Juho Vepsäläinen](https://github.com/bebraw/) - Creator and former maintainer of pypandoc
 
 
 ## License


### PR DESCRIPTION
For verification re the name change: please check e.g. https://github.com/JessicaTegner/pypandoc/commit/1ab24711fb63bbab1115efd6406810ac2bf0a4ee.patch (shows the old name) vs https://github.com/JessicaTegner/pypandoc/commit/1ab24711fb63bbab1115efd6406810ac2bf0a4ee (shows the new name/github handle). Funnily, github.com/janschulz is not myself (anymore?)...