### PR TITLE
Remove logic for python2

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -13,10 +13,11 @@ import textwrap
 import glob
 from pathlib import Path
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from .handler import _check_log_handler
 from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
-from .py3compat import cast_bytes, cast_unicode, url2path
+from .py3compat import cast_bytes, cast_unicode
 
 __author__ = u'Juho Vepsäläinen'
 __author_email__ = "bebraw@gmail.com"
@@ -52,6 +53,11 @@ __all__ = ['convert_file', 'convert_text',
 
 # Set up the module level logger
 logger = logging.getLogger(__name__)
+
+def url2path(url):  # noqa: E303
+    # from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
+    return url2pathname(urlparse(url).path)
+
 
 def convert_text(source:str, to:str, format:str, extra_args:Iterable=(), encoding:str='utf-8',
                  outputfile:Union[None, str, Path]=None, filters:Union[Iterable, None]=None, verify_format:bool=True,

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -17,7 +17,7 @@ from urllib.request import url2pathname
 
 from .handler import _check_log_handler
 from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
-from .py3compat import cast_bytes, cast_unicode
+from .py3compat import cast_unicode
 
 __author__ = u'Juho Vepsäläinen'
 __author_email__ = "bebraw@gmail.com"
@@ -398,7 +398,8 @@ def _convert_input(source, format, input_type, to, extra_args=(),
 
     if string_input:
         try:
-            source = cast_bytes(source, encoding='utf-8')
+            if not isinstance(source, bytes):
+                source = source.encode('utf-8')
         except (UnicodeDecodeError, UnicodeEncodeError):
             # assume that it is already a utf-8 encoded string
             pass

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, with_statement
 from typing import Iterable
 from typing import Union
 from typing import Generator

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -12,10 +12,11 @@ import tempfile
 import textwrap
 import glob
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .handler import _check_log_handler
 from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
-from .py3compat import cast_bytes, cast_unicode, string_types, url2path, urlparse
+from .py3compat import cast_bytes, cast_unicode, url2path
 
 __author__ = u'Juho Vepsäläinen'
 __author_email__ = "bebraw@gmail.com"
@@ -355,7 +356,7 @@ def _convert_input(source, format, input_type, to, extra_args=(),
 
     # adds the proper filter syntax for each item in the filters list
     if filters is not None:
-        if isinstance(filters, string_types):
+        if isinstance(filters, str):
             filters = filters.split()
         f = ['--lua-filter=' + x if x.endswith(".lua") else '--filter=' + x for x in filters]
         args.extend(f)

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -17,7 +17,7 @@ from urllib.request import url2pathname
 
 from .handler import _check_log_handler
 from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
-from .py3compat import cast_unicode
+from .py3compat import _DEFAULT_ENCODING
 
 __author__ = u'Juho Vepsäläinen'
 __author_email__ = "bebraw@gmail.com"
@@ -244,7 +244,10 @@ def _as_unicode(source:any, encoding:str) -> any:
         # if a source and a different encoding is given, try to decode the the source into a
         # unicode string
         try:
-            source = cast_unicode(source, encoding=encoding)
+            if isinstance(source, bytes):
+                encoding = encoding or _DEFAULT_ENCODING
+                source = source.decode(encoding)
+            
         except (UnicodeDecodeError, UnicodeEncodeError):
             pass
     return source

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -9,13 +9,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Union
-
 import urllib
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib import urlopen
+from typing import Union
+from urllib.request import urlopen
 
 from .handler import _check_log_handler
 

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -38,11 +38,6 @@ def cast_bytes(s, encoding=None):
         return _encode(s, encoding)
     return s
 
-PY3 = True
-
-string_types = (str,)
-unicode_type = str
-
 # from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
 from urllib.parse import urljoin, urlparse
 from urllib.request import pathname2url, url2pathname

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -37,15 +37,3 @@ def cast_bytes(s, encoding=None):
     if not isinstance(s, bytes):
         return _encode(s, encoding)
     return s
-
-# from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
-from urllib.parse import urljoin, urlparse
-from urllib.request import pathname2url, url2pathname
-
-
-def path2url(path):  # noqa: E303
-    return urljoin('file:', pathname2url(path))
-
-
-def url2path(url):  # noqa: E303
-    return url2pathname(urlparse(url).path)

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -38,38 +38,19 @@ def cast_bytes(s, encoding=None):
         return _encode(s, encoding)
     return s
 
+PY3 = True
 
-if sys.version_info[0] >= 3:
-    PY3 = True
+string_types = (str,)
+unicode_type = str
 
-    string_types = (str,)
-    unicode_type = str
-
-    # from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
-    from urllib.parse import urljoin, urlparse
-    from urllib.request import pathname2url, url2pathname
+# from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
+from urllib.parse import urljoin, urlparse
+from urllib.request import pathname2url, url2pathname
 
 
-    def path2url(path):  # noqa: E303
-        return urljoin('file:', pathname2url(path))
+def path2url(path):  # noqa: E303
+    return urljoin('file:', pathname2url(path))
 
 
-    def url2path(url):  # noqa: E303
-        return url2pathname(urlparse(url).path)
-
-else:
-    PY3 = False
-
-    string_types = (str, unicode)  # noqa: F821
-    unicode_type = unicode  # noqa: F821
-
-    from urlparse import urljoin, urlparse
-    import urllib
-
-
-    def path2url(path):  # noqa: E303
-        return urljoin('file:', urllib.pathname2url(path))
-
-
-    def url2path(url):  # noqa: E303
-        return urllib.url2pathname(urlparse(url).path)
+def url2path(url):  # noqa: E303
+    return url2pathname(urlparse(url).path)

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -20,20 +20,7 @@ def _decode(s, encoding=None):
     encoding = encoding or _DEFAULT_ENCODING
     return s.decode(encoding)
 
-
-def _encode(u, encoding=None):
-    encoding = encoding or _DEFAULT_ENCODING
-    return u.encode(encoding)
-
-
 def cast_unicode(s, encoding=None):
     if isinstance(s, bytes):
         return _decode(s, encoding)
-    return s
-
-
-def cast_bytes(s, encoding=None):
-    # bytes == str on py2.7 -> always encode on py2
-    if not isinstance(s, bytes):
-        return _encode(s, encoding)
     return s

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
-
 import locale
 import sys
 

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -14,13 +14,3 @@ except Exception:
     pass
 
 _DEFAULT_ENCODING = _DEFAULT_ENCODING or sys.getdefaultencoding()
-
-
-def _decode(s, encoding=None):
-    encoding = encoding or _DEFAULT_ENCODING
-    return s.decode(encoding)
-
-def cast_unicode(s, encoding=None):
-    if isinstance(s, bytes):
-        return _decode(s, encoding)
-    return s

--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,8 @@ import textwrap
 import unittest
 import warnings
 from pathlib import Path
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
 import pypandoc
 
@@ -220,7 +222,9 @@ class TestPypandoc(unittest.TestCase):
             expected = u'some title{0}=========={0}{0}'.format(os.linesep)
             # this keeps the : (which should be '|' on windows but pandoc
             # doesn't like it
-            file_url = path2url(file_name)
+
+            # from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
+            file_url = urljoin('file:', pathname2url(file_name))
             assert pypandoc._identify_path(file_url)
 
             received = pypandoc.convert_file(file_url, 'rst')

--- a/tests.py
+++ b/tests.py
@@ -16,7 +16,6 @@ import warnings
 from pathlib import Path
 
 import pypandoc
-from pypandoc.py3compat import path2url, string_types, unicode_type
 
 
 @contextlib.contextmanager
@@ -53,7 +52,7 @@ def closed_tempfile(suffix, text=None, dir_name=None):
 # Stolen from pandas
 def is_list_like(arg):
     return (hasattr(arg, '__iter__') and
-            not isinstance(arg, string_types))
+            not isinstance(arg, str))
 
 
 @contextlib.contextmanager
@@ -155,7 +154,7 @@ class TestPypandoc(unittest.TestCase):
     def test_get_pandoc_version(self):
         assert "HOME" in os.environ, "No HOME set, this will error..."
         version = pypandoc.get_pandoc_version()
-        self.assertTrue(isinstance(version, pypandoc.string_types))
+        self.assertTrue(isinstance(version, str))
         major = int(version.split(".")[0])
         # according to http://pandoc.org/releases.html there were only two versions 0.x ...
         self.assertTrue(major in [0, 1, 2])
@@ -490,12 +489,12 @@ class TestPypandoc(unittest.TestCase):
         # make sure that pandoc always returns unicode and does not mishandle it
         expected = u'üäöîôû{0}'.format(os.linesep)
         written = pypandoc.convert_text(u'<p>üäöîôû</p>', 'md', format='html')
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
         self.assertEqualExceptForNewlineEnd(expected, written)
         bytes = u'<p>üäöîôû</p>'.encode("utf-8")
         written = pypandoc.convert_text(bytes, 'md', format='html')
         self.assertTrue(expected == written)
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
 
         # Only use german umlauts in the next test, as iso-8859-15 covers that
         expected = u'äüäö{0}'.format(os.linesep)
@@ -516,7 +515,7 @@ class TestPypandoc(unittest.TestCase):
         # with the right encoding it should work...
         written = pypandoc.convert_text(bytes, 'md', format='html', encoding="iso-8859-15")
         self.assertEqualExceptForNewlineEnd(expected, written)
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
 
     def test_conversion_from_non_plain_text_file(self):
         with closed_tempfile('.docx') as file_name:


### PR DESCRIPTION
The library currently cannot be installed on py2 because of `setup_requires=">=3.6"`
So, remove code for python 2