### PR TITLE
ci: Fix conditions for building and publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
 
   builder_pypandoc_binary:
     needs: [test]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/v')
     strategy:
       matrix:
         # Ref: https://cibuildwheel.readthedocs.io/en/stable/options/#archs
@@ -103,7 +103,7 @@ jobs:
 
   publisher_release:
     needs: [builder_pypandoc, builder_pypandoc_binary]
-    if: startsWith(github.event.ref, 'refs/tags/v') && github.ref == 'refs/heads/master'
+    if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
 
   builder_pypandoc_binary:
     needs: [test]
-    if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         # Ref: https://cibuildwheel.readthedocs.io/en/stable/options/#archs
@@ -103,7 +103,7 @@ jobs:
 
   publisher_release:
     needs: [builder_pypandoc, builder_pypandoc_binary]
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Based ont he github documentation:

github.events.ref: Is the ref of a release that has been created github.ref: If the branch that is being used (depending on the action)
 - create a release:      It will be refs/tags/<tag_name>
 - create a pull request: It will be refs/pull/<pr_number>/merge
 - push to a branch:      It will be refs/heads/<branch_name>

For publishing to pypi, we are targeting the "create a release" event. In which case:
 - github.events.ref will be refs/tags/<tag_name>
 - github.ref will also be refs/tags/<tag_name>

So, it looks like our IF condition was incorrect.

Ref: https://docs.github.com/en/actions/learn-github-actions/environment-variables