### PR TITLE
Add release.md to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include README.md
 include LICENSE
 include tests.py
 include filter_test.md
+include release.md
 include examples/*


### PR DESCRIPTION
This should fix `test_basic_conversion_from_file_pattern` and `test_basic_conversion_from_file_pattern_with_input_list` when ran on the released code.

These tests check for the presence of the string `making a release` which is taken from `release.md`. Therefore, `release.md` must be in the release tarball.

See also https://github.com/JessicaTegner/pypandoc/pull/259/files#r1126859693

However, this PR has not been tested.
