### PR TITLE
Change when we do source file verification

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -137,20 +137,15 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
     :raises OSError: if pandoc is not found; make sure it has been installed and is available at
             path.
     """
+    # check if we have a working directory
+    # if we don't, we use the current working directory
+    if cworkdir is None:
+        cworkdir = os.getcwd()
+
     # TODO: remove 'encoding' parameter and warning
     if encoding != "utf-8":
         logger.warning("The 'encoding' parameter will be removed in version 1.13. Just remove the parameter, because currently the method does not use it.")
 
-    # This if block effectively adds support for pathlib.Path objects
-    # and generators produced by pathlib.Path().glob().
-    if not isinstance(source_file, str):
-        try:
-            source_file = list(map(str, source_file))
-        except TypeError:
-            source_file = str(source_file)
-
-    if not _identify_path(source_file):
-        raise RuntimeError("source_file is not a valid path")
     if _is_network_path(source_file): # if the source_file is an url
         format = _identify_format_from_path(source_file, format)
         return _convert_input(source_file, format, 'path', to, extra_args=extra_args,
@@ -158,13 +153,45 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
                           verify_format=verify_format, sandbox=sandbox,
                           cworkdir=cworkdir)
 
-    discovered_source_files = []
+    # convert the source file to a path object internally
     if isinstance(source_file, str):
-        discovered_source_files += glob.glob(source_file)
-    if isinstance(source_file, list): # a list of possibly file or file patterns. Expand all with glob
-        for filepath in source_file:
-            discovered_source_files.extend(glob.glob(filepath))
+        source_file = Path(source_file)
+    elif isinstance(source_file, list):
+        source_file = [Path(x) for x in source_file]
+    elif isinstance(source_file, Generator):
+        source_file = [Path(x) for x in source_file]
 
+
+    # we are basically interested to figure out if its an absolute path or not
+    # if it's not, we want to prefix the working directory
+    # if it's a list, we want to prefix the working directory to each item if it's not an absolute path
+    # if it is, just use the absolute path
+    if isinstance(source_file, list):
+        source_file = [x if x.is_absolute() else Path(cworkdir, x) for x in source_file]
+    elif isinstance(source_file, Generator):
+        source_file = (x if x.is_absolute() else Path(cworkdir, x) for x in source_file)
+    # check ifjust a single path was given
+    elif isinstance(source_file, Path):
+        source_file = source_file if source_file.is_absolute() else Path(cworkdir, source_file)
+
+
+    discovered_source_files = []
+    # if we have a list of files, we need to glob them
+    # if we have a single file, we need to glob it
+    # remember that we already converted the source_file to a path object
+    # so for glob.glob use both the dir and file name
+    if isinstance(source_file, list):
+        for single_source in source_file:
+            discovered_source_files.extend(glob.glob(str(single_source)))
+        if discovered_source_files == []:
+            discovered_source_files = source_file
+    else:
+        discovered_source_files.extend(glob.glob(str(source_file)))
+        if discovered_source_files == []:
+            discovered_source_files = [source_file]
+
+    if not _identify_path(discovered_source_files):
+        raise RuntimeError("source_file is not a valid path")
     format = _identify_format_from_path(discovered_source_files[0], format)
     if len(discovered_source_files) == 1:
         discovered_source_files = discovered_source_files[0]


### PR DESCRIPTION
Change when we do source file verification #342. Previously we did sourceverificiation before looking at the working directory. Now we convert all source files to an absolute file path if needed, then perform globbing and then do source verification. This fixes a bug where we would not find source files if the working directory was not the same as the source file directory.                
