### PR TITLE
fix: shell path error

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -161,6 +161,7 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
 
     discovered_source_files = []
     if isinstance(source_file, str):
+        source_file = source_file.replace('[', '[[]')
         discovered_source_files += glob.glob(source_file)
     if isinstance(source_file, list): # a list of possibly file or file patterns. Expand all with glob
         for filepath in source_file:


### PR DESCRIPTION
文件名中包含[时，如：XXX[123].XXX.docx，在MacOS中执行报错如下：
python3.10/site-packages/pypandoc/__init__.py", line 164, in convert_file
    format = _identify_format_from_path(discovered_source_files[0], format)
IndexError: list index out of range

修复：将[改为[[