### PR TITLE
Removed python 3.6 CI and fixed test cases for python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0", "pypy3.8", "pypy3.9", "pypy3.10", ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0", "pypy3.8", "pypy3.9", "pypy3.10", ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,21 +14,22 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "58.0.0"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "setuptools-58.0.0-py3-none-any.whl", hash = "sha256:fa14855ea8332dc12cae21b8e18cf55573eeaabad9fe3b8b787e6a74e01885d3"},
-    {file = "setuptools-58.0.0.tar.gz", hash = "sha256:ee45f4d69c4bbd21a27b60a7f1f32cbdcd34755cb613e5c4edcb58145394a0a3"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
-testing = ["flake8-2020", "jaraco.envs", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.6,<=3.12"
-content-hash = "1c367fd2ab37be9a87a59792bc2e65b1e1a35b61e8f01e4ca1b234899d56a1c4"
+python-versions = ">=3.7,<=3.12"
+content-hash = "75e276169cb2c21b09878cb017e668d697e3996a98be34f7299c8cca03e448d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,15 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6,<=3.12"
+python = ">=3.7,<=3.12"
 
 [tool.poetry.dev-dependencies]
 pandocfilters = "^1.5"
-setuptools = "58"
+setuptools = "68"
 
 [tool.poetry.group.dev.dependencies]
 pandocfilters = "^1.5"
-setuptools = "58"
+setuptools = "68"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests.py
+++ b/tests.py
@@ -409,13 +409,21 @@ class TestPypandoc(unittest.TestCase):
                     markdown_source, to="html", format="md", outputfile=None, filters=[temp1, temp2, temp3, temp4]
                 ).strip()
                 expected = "<p>-0-1-2-3-4-</p>"
-                self.assertEquals(output, expected)
+                try:
+                    self.assertEquals(output, expected)
+                except AttributeError:
+                    # python 3.12 doesn't have assertEqual
+                    self.assertEqual(output, expected)
 
                 output = pypandoc.convert_text(
                     markdown_source, to="html", format="md", outputfile=None, filters=[temp3, temp1, temp4, temp2]
                 ).strip()
                 expected = "<p>-0-3-1-4-2-</p>"
-                self.assertEquals(output, expected)
+                try:
+                    self.assertEquals(output, expected)
+                except AttributeError:
+                    # python 3.12 doesn't have assertEqual
+                    self.assertEqual(output, expected)
 
     def test_classify_pandoc_logging(self):
         


### PR DESCRIPTION
There were some test cases failing on  python 3.12 due to UnitTest.TestCase assertEquals raising an AttributeError on python 3.12.
In addition, download pandoc in CO failed due to missing setuptools, so python 3.6 has been removed from CI to allowfor installation of a recent version of setuptools