### PR TITLE
Use the latest version of pandoc when building pypandoc_binary, instead of hardcoding the version number

### DIFF
--- a/setup_binary.py
+++ b/setup_binary.py
@@ -35,7 +35,7 @@ class DownloadPandocCommand(Command):
     def run(self):
         from pypandoc.pandoc_download import download_pandoc
         targetfolder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pypandoc", "files")
-        download_pandoc(targetfolder=targetfolder, version="2.19.2")
+        download_pandoc(targetfolder=targetfolder)
 
 
 cmd_classes = {'download_pandoc': DownloadPandocCommand}


### PR DESCRIPTION
Thanks to @hideintheclouds in #375 this pr removes the hardcoded version number used in setup_binary.py when building pypandoc_binary. This now means that we use the latest available version of pandoc.
This is a good solution, until a solution can be created where we can have multiple pypandoc_binary versions with the same pypandoc version, but with different packaged pandoc versions