### PR TITLE
Added parameter to control if files are sorted before being passed to pandoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Alex Kneisel](https://github.com/hey-thanks/) - Added pathlib.Path support to convert_file.
 * [Juho Vepsäläinen](https://github.com/bebraw/) - Creator and former maintainer of pypandoc
 * [Connor](https://github.com/DisSupEng/) - Updated Dockerfile to Python 3.9 image and added docker compose file
+* [Colin Bull](https://github.com/colinbull) - Added ability to control whether files are sorted before being passed to pandoc process.
 
 ## License
 

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -133,9 +133,9 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
     :param bool sandbox: Run pandoc in pandocs own sandbox mode, limiting IO operations in readers and writers to reading the files specified on the command line. Anyone using pandoc on untrusted user input should use this option. Note: This only does something, on pandoc >= 2.15
             (Default value = False)
 
-    :param bool sort_files: causes the files to be sorted before being passed to pandoc (Default value = True)
-
     :param str cworkdir: set the current working directory (Default value = None)
+
+    :param bool sort_files: causes the files to be sorted before being passed to pandoc (Default value = True)
 
     :returns: converted string (unicode) or an empty string if an outputfile was given
     :rtype: unicode

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -81,6 +81,8 @@ def convert_text(source:str, to:str, format:str, extra_args:Iterable=(), encodin
     :param bool sandbox: Run pandoc in pandocs own sandbox mode, limiting IO operations in readers and writers to reading the files specified on the command line. Anyone using pandoc on untrusted user input should use this option. Note: This only does something, on pandoc >= 2.15
             (Default value = False)
 
+    :param str cworkdir: set the current working directory (Default value = None)
+
     :returns: converted string (unicode) or an empty string if an outputfile was given
     :rtype: unicode
 
@@ -98,7 +100,7 @@ def convert_text(source:str, to:str, format:str, extra_args:Iterable=(), encodin
 def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:Union[str, None]=None,
                  extra_args:Iterable=(), encoding:str='utf-8', outputfile:Union[None, str, Path]=None,
                  filters:Union[Iterable, None]=None, verify_format:bool=True, sandbox:bool=False,
-                 cworkdir:Union[str, None]=None) -> str:
+                 cworkdir:Union[str, None]=None, sort_files=True) -> str:
     """Converts given `source` from `format` to `to`.
 
     :param (str, list, pathlib.Path) source_file: If a string, should be either
@@ -130,6 +132,10 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
 
     :param bool sandbox: Run pandoc in pandocs own sandbox mode, limiting IO operations in readers and writers to reading the files specified on the command line. Anyone using pandoc on untrusted user input should use this option. Note: This only does something, on pandoc >= 2.15
             (Default value = False)
+
+    :param bool sort_files: causes the files to be sorted before being passed to pandoc (Default value = True)
+
+    :param str cworkdir: set the current working directory (Default value = None)
 
     :returns: converted string (unicode) or an empty string if an outputfile was given
     :rtype: unicode
@@ -200,7 +206,7 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
     return _convert_input(discovered_source_files, format, 'path', to, extra_args=extra_args,
                       outputfile=outputfile, filters=filters,
                       verify_format=verify_format, sandbox=sandbox,
-                      cworkdir=cworkdir)
+                      cworkdir=cworkdir, sort_files=sort_files)
 
 
 def _identify_path(source) -> bool:
@@ -356,7 +362,7 @@ def _validate_formats(format, to, outputfile):
 
 def _convert_input(source, format, input_type, to, extra_args=(),
                    outputfile=None, filters=None, verify_format=True,
-                   sandbox=False, cworkdir=None):
+                   sandbox=False, cworkdir=None, sort_files=True):
     
     _check_log_handler()
 
@@ -379,8 +385,10 @@ def _convert_input(source, format, input_type, to, extra_args=(),
             input_file = source
     else:
         input_file = []
-    
-    input_file = sorted(input_file)
+
+    if sort_files:
+        input_file = sorted(input_file)
+
     args = [__pandoc_path, '--from=' + format]
 
     args.append('--to=' + to)

--- a/tests.py
+++ b/tests.py
@@ -31,13 +31,13 @@ def capture(command, *args, **kwargs):
 
 
 @contextlib.contextmanager
-def closed_tempfile(suffix, text=None, dir_name=None):
+def closed_tempfile(suffix, text=None, dir_name=None, prefix=None):
     file_name = None
     try:
         if dir_name:
             dir_name = tempfile.mkdtemp(suffix=dir_name)
 
-        with tempfile.NamedTemporaryFile('w+t', suffix=suffix, delete=False, dir=dir_name) as test_file:
+        with tempfile.NamedTemporaryFile('w+t', suffix=suffix, prefix=prefix, delete=False, dir=dir_name) as test_file:
             file_name = test_file.name
             if text:
                 test_file.write(text)
@@ -199,6 +199,13 @@ class TestPypandoc(unittest.TestCase):
             with closed_tempfile('.md', text='some title') as file_name2:
                 expected = '<p>some title</p>\n<p>some title</p>'
                 received = pypandoc.convert_file([file_name1,file_name2], 'html')
+                self.assertEqualExceptForNewlineEnd(expected, received)
+
+    def test_sorting_rules_applied_for_multiple_files(self):
+        with closed_tempfile('.md', prefix='1_', text='some title 1') as file_name1:
+            with closed_tempfile('.md', prefix='2_', text='some title 2') as file_name2:
+                expected = '<p>some title 2</p>\n<p>some title 1</p>'
+                received = pypandoc.convert_file([file_name2,file_name1], 'html', sort_files=False)
                 self.assertEqualExceptForNewlineEnd(expected, received)
 
     def test_basic_conversion_from_file_pattern(self):


### PR DESCRIPTION
Small PR to allow the sorting behaviour to be controlled before the file sets are passed to the pandoc process. Previously files were always sorted. However, this can lead to the wrong ordering in the generated documents if the sorted order file names don't represent the required order in the generated documents.