### PR TITLE
Added support for python 3.13 - Removed ubber bound

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-13, windows-2022]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10", ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10", ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,5 +29,5 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<3.13"
-content-hash = "91117101dea3dbd85e5bf7ea003e83307ede9f377e04931c1e4b7d071b2053f3"
+python-versions = ">=3.7"
+content-hash = "ed7b5108aaa0e505021fa0a65efcc0da68f74e344ab9d0b341182ba8f73403eb"

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -24,7 +24,7 @@ __url__ = 'https://github.com/JessicaTegner/pypandoc'
 __version__ = '1.14'
 __license__ = 'MIT'
 __description__ = "Thin wrapper for pandoc."
-__python_requires__ = ">=3.6"
+__python_requires__ = ">=3.7"
 __setup_requires__ = ['setuptools', 'pip>=8.1.0', 'wheel>=0.25.0']
 __classifiers__ = [
         'Development Status :: 4 - Beta',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.13"
+python = ">=3.7"
 
 [tool.poetry.dev-dependencies]
 pandocfilters = "^1.5"


### PR DESCRIPTION
Supersets #360 

This pr does the following

* Adds python 3.13 to CI
* Removed ubber bounds in "python requires" in pyproject and setup(-binary).py