### PR TITLE
Fix convert_file for Python 3.13

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, with_statement
 from typing import Iterable
+from typing import Iterator
 from typing import Union
-from typing import Generator
 
 import os
 import re
@@ -97,7 +97,7 @@ def convert_text(source:str, to:str, format:str, extra_args:Iterable=(), encodin
                           cworkdir=cworkdir)
 
 
-def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:Union[str, None]=None,
+def convert_file(source_file:Union[list, str, Path, Iterator], to:str, format:Union[str, None]=None,
                  extra_args:Iterable=(), encoding:str='utf-8', outputfile:Union[None, str, Path]=None,
                  filters:Union[Iterable, None]=None, verify_format:bool=True, sandbox:bool=False,
                  cworkdir:Union[str, None]=None, sort_files=True) -> str:
@@ -165,7 +165,7 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
         source_file = Path(source_file)
     elif isinstance(source_file, list):
         source_file = [Path(x) for x in source_file]
-    elif isinstance(source_file, Generator):
+    elif isinstance(source_file, Iterator):
         source_file = [Path(x) for x in source_file]
 
 
@@ -175,7 +175,7 @@ def convert_file(source_file:Union[list, str, Path, Generator], to:str, format:U
     # if it is, just use the absolute path
     if isinstance(source_file, list):
         source_file = [x if x.is_absolute() else Path(cworkdir, x) for x in source_file]
-    elif isinstance(source_file, Generator):
+    elif isinstance(source_file, Iterator):
         source_file = (x if x.is_absolute() else Path(cworkdir, x) for x in source_file)
     # check ifjust a single path was given
     elif isinstance(source_file, Path):


### PR DESCRIPTION
As of https://github.com/python/cpython/pull/117589 (at least), `Path.glob` returns an `Iterator` rather than `Generator` (which inherits from `Iterator`).  `convert_file` doesn't need to care about this distinction; it can reasonably accept both.

This previously caused a test failure along these lines:

```
______________________________________________________ TestPypandoc.test_basic_conversion_from_file_pattern_pathlib_glob _______________________________________________________

self = <tests.TestPypandoc testMethod=test_basic_conversion_from_file_pattern_pathlib_glob>

    def test_basic_conversion_from_file_pattern_pathlib_glob(self):
        received_from_str_filename_input = pypandoc.convert_file("./*.md", 'html').lower()
>       received_from_path_filename_input = pypandoc.convert_file(Path(".").glob("*.md"), 'html').lower()

tests.py:654:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source_file = <map object at 0x7f83952c9420>, to = 'html', format = None, extra_args = (), encoding = 'utf-8', outputfile = None, filters = None, verify_format = True
sandbox = False, cworkdir = '/home/cjwatson/src/python/pypandoc', sort_files = True
[...]
        if not _identify_path(discovered_source_files):
>           raise RuntimeError("source_file is not a valid path")
E           RuntimeError: source_file is not a valid path

pypandoc/__init__.py:201: RuntimeError
```