### PR TITLE
Dropped CI support for older python and pypy versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-13, windows-2022]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10", ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10", ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
This pr drops CI support for python 3.7, 3.8 and pypy 3.8

Noting that this doesn't mean that pypandoc and pypandoc_binary wont install on the above versions, just that they are not runned in CI.
