### PR TITLE
Remove the Python 3.6 PyPI trove classifier

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -37,7 +37,6 @@ __classifiers__ = [
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Filters',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Filters',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This is no longer needed because Python 3.7+ is required.

I haven't added myself as a contributor because this is too trivial.

Thanks for your work on pypandoc!