### PR TITLE
Begin removing Python 2 compatibility code

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from .handler import logger, _check_log_handler
 from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
-from .py3compat import cast_bytes, cast_unicode, string_types, url2path, urlparse
+from .py3compat import cast_bytes, cast_unicode, url2path, urlparse
 
 __author__ = u'Juho Vepsäläinen'
 __author_email__ = "bebraw@gmail.com"
@@ -406,7 +406,7 @@ def _convert_input(source, format, input_type, to, extra_args=(),
 
     # adds the proper filter syntax for each item in the filters list
     if filters is not None:
-        if isinstance(filters, string_types):
+        if isinstance(filters, str):
             filters = filters.split()
         f = ['--lua-filter=' + x if x.endswith(".lua") else '--filter=' + x for x in filters]
         args.extend(f)

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -70,8 +70,7 @@ def _get_pandoc_urls(version="latest"):
         'pkg': 'darwin'
     }
     # parse pandoc_urls from list to dict
-    # py26 don't like dict comprehension. Use this one instead when py26 support is dropped
-    pandoc_urls = {ext2platform[url_frag[-3:]]: (f"https://github.com{url_frag}") for url_frag in pandoc_urls_list}
+    pandoc_urls = {ext2platform[url_frag[-3:]]: f"https://github.com{url_frag}" for url_frag in pandoc_urls_list}
     return pandoc_urls, version
 
 

--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -41,37 +41,14 @@ def cast_bytes(s, encoding=None):
     return s
 
 
-if sys.version_info[0] >= 3:
-    PY3 = True
-
-    string_types = (str,)
-    unicode_type = str
-
-    # from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
-    from urllib.parse import urljoin, urlparse
-    from urllib.request import pathname2url, url2pathname
+# from http://stackoverflow.com/questions/11687478/convert-a-filename-to-a-file-url
+from urllib.parse import urljoin, urlparse
+from urllib.request import pathname2url, url2pathname
 
 
-    def path2url(path):  # noqa: E303
-        return urljoin('file:', pathname2url(path))
+def path2url(path):  # noqa: E303
+    return urljoin('file:', pathname2url(path))
 
 
-    def url2path(url):  # noqa: E303
-        return url2pathname(urlparse(url).path)
-
-else:
-    PY3 = False
-
-    string_types = (str, unicode)  # noqa: F821
-    unicode_type = unicode  # noqa: F821
-
-    from urlparse import urljoin, urlparse
-    import urllib
-
-
-    def path2url(path):  # noqa: E303
-        return urljoin('file:', urllib.pathname2url(path))
-
-
-    def url2path(url):  # noqa: E303
-        return urllib.url2pathname(urlparse(url).path)
+def url2path(url):  # noqa: E303
+    return url2pathname(urlparse(url).path)

--- a/tests.py
+++ b/tests.py
@@ -16,7 +16,7 @@ import warnings
 from pathlib import Path
 
 import pypandoc
-from pypandoc.py3compat import path2url, string_types, unicode_type
+from pypandoc.py3compat import path2url
 
 
 @contextlib.contextmanager
@@ -53,7 +53,7 @@ def closed_tempfile(suffix, text=None, dir_name=None, prefix=None):
 # Stolen from pandas
 def is_list_like(arg):
     return (hasattr(arg, '__iter__') and
-            not isinstance(arg, string_types))
+            not isinstance(arg, str))
 
 
 @contextlib.contextmanager
@@ -129,10 +129,6 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
 
 class TestPypandoc(unittest.TestCase):
 
-    # Python 2 compatibility
-    if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
-        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
     def setUp(self):
         if 'HOME' not in os.environ:
             # if this is used with older versions of pandoc-citeproc
@@ -155,7 +151,7 @@ class TestPypandoc(unittest.TestCase):
     def test_get_pandoc_version(self):
         assert "HOME" in os.environ, "No HOME set, this will error..."
         version = pypandoc.get_pandoc_version()
-        self.assertTrue(isinstance(version, pypandoc.string_types))
+        self.assertTrue(isinstance(version, str))
         major = int(version.split(".")[0])
         self.assertTrue(major in [0, 1, 2, 3])
 
@@ -524,12 +520,12 @@ class TestPypandoc(unittest.TestCase):
         # make sure that pandoc always returns unicode and does not mishandle it
         expected = u'üäöîôû{0}'.format(os.linesep)
         written = pypandoc.convert_text(u'<p>üäöîôû</p>', 'md', format='html')
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
         self.assertEqualExceptForNewlineEnd(expected, written)
         bytes = u'<p>üäöîôû</p>'.encode("utf-8")
         written = pypandoc.convert_text(bytes, 'md', format='html')
         self.assertTrue(expected == written)
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
 
         # Only use german umlauts in the next test, as iso-8859-15 covers that
         expected = u'äüäö{0}'.format(os.linesep)
@@ -550,7 +546,7 @@ class TestPypandoc(unittest.TestCase):
         # with the right encoding it should work...
         written = pypandoc.convert_text(bytes, 'md', format='html', encoding="iso-8859-15")
         self.assertEqualExceptForNewlineEnd(expected, written)
-        self.assertTrue(isinstance(written, unicode_type))
+        self.assertTrue(isinstance(written, str))
 
     def test_conversion_from_non_plain_text_file(self):
         with closed_tempfile('.docx') as file_name:


### PR DESCRIPTION
This is not comprehensive because there is no coverage report to confirm what code paths are exercised by the test suite.

However, it is a start.