### PR TITLE
Add FUNDING.yml with sponsorship links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,4 @@
 github: JessicaTegner
-custom:
-  - https://thanks.dev/JessicaTegner
-  - https://polar.sh/JessicaTegner
-  - https://tidelift.com/subscription/pkg/pypi-pypandoc
-  - https://tidelift.com/subscription/pkg/pypi-pypandoc-binary
+tidelift: pypi/pypandoc
+polar: JessicaTegner
+thanks_dev: u/gh/JessicaTegner


### PR DESCRIPTION
Adds a FUNDING.yml to show the Sponsor button on the repo page.

Links included:
- GitHub Sponsors
- Thanks.dev
- Polar.sh
- Tidelift (pypandoc + pypandoc_binary)

pypandoc is downloaded 14M+ times per month — making it easy for users and companies to support its continued maintenance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds repository metadata only; no runtime code or behavior changes.
> 
> **Overview**
> Adds `.github/FUNDING.yml` to enable GitHub’s Sponsor button and advertise project funding links (GitHub Sponsors, Tidelift for `pypi/pypandoc`, Polar, and Thanks.dev).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a589d4f7ebd51880c992d9303308e897e5dbcebc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->