### PR TITLE
Fix glob special characters in filenames causing TypeError

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -183,13 +183,24 @@ def convert_file(
             cworkdir=cworkdir,
         )
 
-    # convert the source file to a path object internally
+    # Track which inputs were originally Path objects (literal filenames)
+    # vs strings (which may contain intentional glob patterns like "*.md").
+    # Path objects must have glob special characters (*, ?, [) escaped to
+    # prevent misinterpretation — e.g. "file [2024].epub" would otherwise
+    # treat "[2024]" as a glob character class.
+    # See: https://github.com/JessicaTegner/pypandoc/issues/374
     if isinstance(source_file, str):
+        source_file_is_literal = False
         source_file = Path(source_file)
     elif isinstance(source_file, list):
+        source_file_is_literal = [isinstance(x, Path) for x in source_file]
         source_file = [Path(x) for x in source_file]
     elif isinstance(source_file, Iterator):
         source_file = [Path(x) for x in source_file]
+        source_file_is_literal = [True] * len(source_file)
+    else:
+        # Already a Path object
+        source_file_is_literal = True
 
     # we are basically interested to figure out if it's an absolute path or not.
     # if it's not, we want to prefix the working directory.
@@ -200,7 +211,7 @@ def convert_file(
         source_file = [x if x.is_absolute() else Path(cworkdir, x) for x in source_file]
     elif isinstance(source_file, Iterator):
         source_file = (x if x.is_absolute() else Path(cworkdir, x) for x in source_file)
-    # check ifjust a single path was given
+    # check if just a single path was given
     elif isinstance(source_file, Path):
         source_file = (
             source_file if source_file.is_absolute() else Path(cworkdir, source_file)
@@ -212,12 +223,18 @@ def convert_file(
     # remember that we already converted the source_file to a path object
     # so for glob.glob use both the dir and file name
     if isinstance(source_file, list):
-        for single_source in source_file:
-            discovered_source_files.extend(glob.glob(str(single_source)))
+        for idx, single_source in enumerate(source_file):
+            path_str = str(single_source)
+            if source_file_is_literal[idx]:
+                path_str = glob.escape(path_str)
+            discovered_source_files.extend(glob.glob(path_str))
         if discovered_source_files == []:
             discovered_source_files = source_file
     else:
-        discovered_source_files.extend(glob.glob(str(source_file)))
+        path_str = str(source_file)
+        if source_file_is_literal:
+            path_str = glob.escape(path_str)
+        discovered_source_files.extend(glob.glob(path_str))
         if discovered_source_files == []:
             discovered_source_files = [source_file]
 
@@ -443,8 +460,10 @@ def _convert_input(
     logger.debug("Identifying input type...")
     string_input = input_type == "string"
     if not string_input:
-        if isinstance(source, str):
-            input_file = [source]
+        if isinstance(source, (str, Path)):
+            input_file = [str(source)]
+        elif isinstance(source, list):
+            input_file = [str(x) for x in source]
         else:
             input_file = source
     else:

--- a/tests/test_pypandoc.py
+++ b/tests/test_pypandoc.py
@@ -837,16 +837,12 @@ class TestPypandoc(unittest.TestCase):
 
     def test_conversion_from_multiple_files_with_brackets(self):
         """Multiple files with brackets in names should all convert correctly."""
-        with closed_tempfile(
-            ".md", text="first title", prefix="test [1] "
-        ) as file1:
+        with closed_tempfile(".md", text="first title", prefix="test [1] ") as file1:
             with closed_tempfile(
                 ".md", text="second title", prefix="test [2] "
             ) as file2:
                 expected = "<p>first title</p>\n<p>second title</p>"
-                received = pypandoc.convert_file(
-                    [Path(file1), Path(file2)], "html"
-                )
+                received = pypandoc.convert_file([Path(file1), Path(file2)], "html")
                 self.assertEqualExceptForNewlineEnd(expected, received)
 
     def assertEqualExceptForNewlineEnd(self, expected, received):  # noqa

--- a/tests/test_pypandoc.py
+++ b/tests/test_pypandoc.py
@@ -803,6 +803,52 @@ class TestPypandoc(unittest.TestCase):
                 written = f.read()
             self.assertEqualExceptForNewlineEnd(expected, written)
 
+    def test_conversion_from_file_with_brackets_in_name(self):
+        """Filenames with brackets should not be interpreted as glob patterns.
+
+        Regression test for https://github.com/JessicaTegner/pypandoc/issues/374
+        Brackets like [2024] in filenames were treated as glob character classes,
+        causing 'PosixPath object is not iterable' TypeError.
+        """
+        with closed_tempfile(
+            ".md", text="# some title\n", prefix="test [2024] "
+        ) as file_name:
+            expected = "some title{0}=========={0}{0}".format(os.linesep)
+            # String input (preserves glob pattern support, but should still work
+            # when the file exists and glob resolves it)
+            received_str = pypandoc.convert_file(file_name, "rst")
+            self.assertEqualExceptForNewlineEnd(expected, received_str)
+            # Path input (must escape glob characters)
+            received_path = pypandoc.convert_file(Path(file_name), "rst")
+            self.assertEqualExceptForNewlineEnd(expected, received_path)
+
+    def test_conversion_from_file_with_glob_chars_in_name(self):
+        """Filenames with other glob special characters (*, ?) via Path input."""
+        # Only test characters that are valid in filenames on the current OS.
+        # On Windows, * and ? are invalid in filenames.
+        if sys.platform != "win32":
+            for char in ["*", "?"]:
+                with closed_tempfile(
+                    ".md", text="# title\n", prefix=f"test {char} file "
+                ) as file_name:
+                    expected = "title{0}====={0}{0}".format(os.linesep)
+                    received = pypandoc.convert_file(Path(file_name), "rst")
+                    self.assertEqualExceptForNewlineEnd(expected, received)
+
+    def test_conversion_from_multiple_files_with_brackets(self):
+        """Multiple files with brackets in names should all convert correctly."""
+        with closed_tempfile(
+            ".md", text="first title", prefix="test [1] "
+        ) as file1:
+            with closed_tempfile(
+                ".md", text="second title", prefix="test [2] "
+            ) as file2:
+                expected = "<p>first title</p>\n<p>second title</p>"
+                received = pypandoc.convert_file(
+                    [Path(file1), Path(file2)], "html"
+                )
+                self.assertEqualExceptForNewlineEnd(expected, received)
+
     def assertEqualExceptForNewlineEnd(self, expected, received):  # noqa
         # output written to a file does not seem to have os.linesep
         # handle everything here by replacing the os linesep by a simple \n


### PR DESCRIPTION
Filenames containing glob special characters (`[`, `]`, `*`, `?`) cause `convert_file()` to crash with `TypeError: 'PosixPath' object is not iterable`.

This is a common real-world problem - filenames like `Book Title [2024].epub` or `Report (v2) [final].docx` trigger the bug because `[2024]` is interpreted as a glob character class.

This should fix #374 (which has also bitten my locally).

The reason for this is actually two related bugs in `convert_file()` and `_convert_input()`:

**Issue 1:** `glob.glob()` interprets special characters in literal filenames. For example, `glob.glob("file [2024].epub")` treats `[2024]` as a character class (match `2`, `0`, `2`, `4`), finds no match, and falls back to keeping a bare `PosixPath` object.

**Issue 2:** When the fallback produces a single-element list, it is unwrapped to a bare `PosixPath` and passed to `_convert_input()`, where `sorted()` fails because `PosixPath` is not iterable. Additionally, the `isinstance` check only handled `str`, not `Path`.

So what I did was to change the behaviour to:

* track whether each input was originally a `Path` object (literal filename) or a `str` (potentially an intentional glob pattern like `"*.md"`). Only escape glob special characters for `Path` inputs using `glob.escape()`.
* In `_convert_input()`, handle `Path` objects and lists by normalizing to `list[str]` before `sorted()`.

This preserves full backward compatibility - string inputs like `*".md"` continue to work as glob patterns.

I also added three tests:

- Filenames with brackets (`test [2024] file.md`), as seen in the scenario from #374
- Filenames with `*` and `?` characters (Linux/macOS only, skipped on Windows where these are invalid)
- Multiple files with brackets in a list

All existing tests continue to pass.